### PR TITLE
use double quotes in query syntax instead of single quotes

### DIFF
--- a/Query/Boolean/ListBooleanCondition.cs
+++ b/Query/Boolean/ListBooleanCondition.cs
@@ -13,7 +13,7 @@ namespace OkayCloudSearch.Query.Boolean
         public override string GetQueryString()
         {
             List<string> stringConditions = Conditions
-                .Select(x => x is string ? "'" + (x as string).Replace(" ", "+") + "'"
+                .Select(x => x is string ? "\"" + (x as string).Replace(" ", "+") + "\""
                     : x.ToString()).ToList();
 
             return "(" + Field + ":(" + String.Join(Conditional, stringConditions) + "))";


### PR DESCRIPTION
Summary: Issue with using get by facet ID when using single quotes instead of double quotes. All unit tests pass.
